### PR TITLE
Extend details for DBStatus: Show hosts mounting the DB

### DIFF
--- a/plugins/check_exchange.ps1
+++ b/plugins/check_exchange.ps1
@@ -199,6 +199,9 @@ Function Get_DataBase_Status () {
 				$totalMountedDb = $mountedDb.Count
 				$retCode = $OK
 				$desc = "All Exchange DB are mounted, Databases: $($mountedDb.Name) Total: $totalDB"
+				foreach ($db in $dblist) {
+				   $desc += "<br/>$($db.Name) is mounted on $($db.MountedOnServer)"
+				}
 			}else {
 				$retCode = $CRITICAL
 				$desc = "The Database: $($notMountedDb.Name) not mounted. [$($notMountedDb.Count)\$($totalDB.Count)]"


### PR DESCRIPTION
In addition to the name of DBs distributed in exchange infrastructure, it would be nice to see the dirstribution on exchange infrastructure. In case of crash a situation of the current DB relocation is useful.

New output looks like this:
OK: All Exchange DB are mounted, Databases: DB01 DB03 DB04 DB02. Total: 4
DB01 is mounted on exchange01.mydoamin.local
DB03 is mounted on exchange01.mydoamin.local
DB04 is mounted on exchange02.mydoamin.local
DB02 is mounted on exchange02.mydoamin.local